### PR TITLE
Update install instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ First of all install dybuk.
 
 ```
 cd /path/to/dybuk
-cargo install
+cargo install --path .
 ```
 
 When that's done, you can pipe Rustc output through dybuk:


### PR DESCRIPTION
On newer versions of rust the `cargo install` command needs a path parameter to install from local path.
